### PR TITLE
feat: v0 ページに BASE オンラインショップへの導線を追加

### DIFF
--- a/v0/index.html
+++ b/v0/index.html
@@ -106,10 +106,14 @@
             </dl>
         </section>
 
-        <section class="text-center">
+        <section class="text-center grid gap-3 justify-items-center">
             <a href="https://lin.ee/yaT5Xtp" target="_blank" rel="noopener"
                 class="inline-block bg-[#06C755] text-white font-bold px-6 py-3 rounded-md hover:brightness-95">
                 LINEで最新情報を受け取る
+            </a>
+            <a href="https://ryosukephoto.base.shop/" target="_blank" rel="noopener"
+                class="inline-block bg-black text-white font-bold px-6 py-3 rounded-md hover:brightness-110">
+                オンラインショップで作品を見る
             </a>
         </section>
 
@@ -149,10 +153,14 @@
             </dl>
         </section>
 
-        <section class="text-center" lang="en">
+        <section class="text-center grid gap-3 justify-items-center" lang="en">
             <a href="https://lin.ee/yaT5Xtp" target="_blank" rel="noopener"
                 class="inline-block bg-[#06C755] text-white font-bold px-6 py-3 rounded-md hover:brightness-95">
                 Get updates on LINE
+            </a>
+            <a href="https://ryosukephoto.base.shop/" target="_blank" rel="noopener"
+                class="inline-block bg-black text-white font-bold px-6 py-3 rounded-md hover:brightness-110">
+                Visit the online shop
             </a>
         </section>
 


### PR DESCRIPTION
## Summary
- 写真展 v0 ページ (`v0/index.html`) に BASE オンラインショップ (https://ryosukephoto.base.shop/) への CTA ボタンを追加
- 日本語セクション・英語セクションの両方で、LINE ボタン直下に黒地ボタンを縦並びで配置 (`grid gap-3 justify-items-center`)

## Test plan
- [ ] ブラウザで `v0/index.html` を開き、日本語/英語両方の CTA が LINE ボタンの下に表示されることを確認
- [ ] 「オンラインショップで作品を見る / Visit the online shop」をクリックして https://ryosukephoto.base.shop/ が新規タブで開くことを確認
- [ ] スマホ幅でレイアウト崩れがないこと